### PR TITLE
Update bundler audit and allow ignoring cves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove `ignored_cves` option, replacing it with `.bundlerauditignore` file support.
+
 ## [0.0.5] - 2019-07-23
 
 - Allow specifying `ignored_cves` argument to `bundle_audit` job

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -123,15 +123,13 @@ jobs:
       - attach_workspace:
           at: ~/tmp
       - run: bundle exec bundle-audit update
-      - when:
-          condition: << parameters.ignored_cves >>
-          steps:
-            - run: bundle exec bundle-audit --ignore << parameters.ignored_cves >>
-      - unless:
-          condition: << parameters.ignored_cves >>
-          steps:
-            # bundle-audit doesn't like it if you use --ignore with NO ignored entries
-            - run: bundle exec bundle-audit
+      # If a .bundlerauditignore file EXISTS and HAS CONTENTS
+      # then we read the CVEs from this file and pass them to the bundler-audit command
+      # Otherwise, we invoke bundler-audit without --ignore args.
+      #
+      # Based upno https://github.com/rubysec/ruby-advisory-db/pull/390#issuecomment-509186921
+      # and https://github.com/rubysec/bundler-audit/pull/215
+      - run: if [ `egrep "^[^#]" .bundlerauditignore | cut -f1 | wc -l` -ne 0 ]; then egrep "^[^#]" .bundlerauditignore | cut -f1 | xargs bundle exec bundle-audit --ignore; else bundle exec bundle-audit; fi
 
   haml_lint:
     description: run the haml-lint command

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -123,7 +123,15 @@ jobs:
       - attach_workspace:
           at: ~/tmp
       - run: bundle exec bundle-audit update
-      - run: bundle exec bundle-audit --ignore << parameters.ignored_cves >>
+      - when:
+          condition: << parameters.ignored_cves >>
+          steps:
+            - run: bundle exec bundle-audit --ignore << parameters.ignored_cves >>
+      - unless:
+          condition: << parameters.ignored_cves >>
+          steps:
+            # bundle-audit doesn't like it if you use --ignore with NO ignored entries
+            - run: bundle exec bundle-audit
 
   haml_lint:
     description: run the haml-lint command


### PR DESCRIPTION
This change is necessary because in order for other tools to be able to ALSO know which CVEs should be ignored, we need that list to exist OUTSIDE of .circleci/config.yml so that we can read it independently.