### PR TITLE
The mysql-client package isn't always available, but default-mysql-cl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- update mysql-client target to be default-mysql-client, so that more linux distros can find it.
+
 ## [0.0.6] - 2019-07-24
 
 - Remove `ignored_cves` option, replacing it with `.bundlerauditignore` file support.

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -65,7 +65,7 @@ commands:
       - when:
           condition: << parameters.mysql_db_type >>
           steps:
-            - run: if [ -e db/structure.sql ]; then sudo apt-get update && sudo apt-get install -y mysql-client; fi
+            - run: if [ -e db/structure.sql ]; then sudo apt-get update && sudo apt-get install -y default-mysql-client; fi
       - unless:
           condition: << parameters.mysql_db_type >>
           steps:


### PR DESCRIPTION
…ient is.

This has shown to fix issues like
`E: Package 'mysql-client' has no installation candidate`