### PR TITLE
Remove default_executor so that all users must specify one themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove default_executor from orb. This will force all users to specify an executor (which is a good thing)
+
 ## [0.0.7] - 2019-08-02
 
 - update mysql-client target to be default-mysql-client, so that more linux distros can find it.

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -1,25 +1,5 @@
 description: "A set of standard steps which we use for projects at Table XI"
 version: 2.1
-executors:
-  default_executor:
-    # The working directory is important, so that we
-    # install/cache everything relative to that location
-    working_directory: ~/tmp
-    docker:
-      - image: circleci/ruby:2.5-node
-        environment:
-          RAILS_ENV: test
-          PGHOST: localhost
-          PGUSER: ubuntu
-          # Bundle paths are necessary so that the gems are installed within the workspace
-          # otherwise, they are installed in /usr/local
-          BUNDLE_PATH: ~/tmp/vendor/bundle
-          BUNDLE_APP_CONFIG: ~/tmp/vendor/bundle
-      - image: circleci/postgres:9-alpine
-        environment:
-          POSTGRES_USER: ubuntu
-          POSTGRES_PASSWORD: ""
-
 commands:
   wait_for_other_builds:
     description: "Ensure no earlier numbered job (of this branch) is running"
@@ -38,7 +18,6 @@ commands:
     parameters:
       executor:
         type: executor
-        default: default_executor
       mysql_db_type:
         type: boolean
         default: false
@@ -56,7 +35,6 @@ commands:
     parameters:
       executor:
         type: executor
-        default: default_executor
       mysql_db_type:
         type: boolean
         default: false
@@ -79,7 +57,6 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: default_executor
       mysql_db_type:
         type: boolean
         default: false
@@ -100,7 +77,6 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: default_executor
 
     executor: << parameters.executor >>
     steps:
@@ -113,7 +89,6 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: default_executor
 
     executor: << parameters.executor >>
     steps:
@@ -133,7 +108,6 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: default_executor
 
     executor: << parameters.executor >>
     steps:
@@ -146,7 +120,6 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: default_executor
       mysql_db_type:
         type: boolean
         default: false
@@ -202,7 +175,6 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: default_executor
       mysql_db_type:
         type: boolean
         default: false


### PR DESCRIPTION
One of the users of this orb did not specify an executor, and the default executor's ruby version differed from their Gemfile, causing a confusing error.