### PR TITLE
Add store_screenshots param

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Run the haml-lint command to check the haml for formatting guidelines
 Run Rspec after waiting for db and loading schema.
 
 This takes an optional parameter of `mysql_db_type`, and `parallelism`.
+This takes an optional parameter of `store_screenshots`, which will allow access to screenshots of failed CI runs.
 This takes an optional parameter of `report_coverage` which will use the (report_coverage)[https://github.com/rdunlop/codeclimate_circle_ci_coverage] gem to send rspec coverage results to CodeClimate.
 
 ### teaspoon

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -122,7 +122,7 @@ jobs:
         type: executor
       store_screenshots:
         type: boolean
-        default: false
+        default: true
       mysql_db_type:
         type: boolean
         default: false
@@ -163,7 +163,10 @@ jobs:
       - store_test_results:
           path: test_results
       - when:
-          condition: << parameters.store_screenshots >>
+          condition:
+            and:
+              - << parameters.store_screenshots >>
+              - not: << parameters.report_coverage >>
           steps:
             - store_artifacts:
               path: tmp/screenshots

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -120,6 +120,9 @@ jobs:
     parameters:
       executor:
         type: executor
+      store_screenshots:
+        type: boolean
+        default: false
       mysql_db_type:
         type: boolean
         default: false
@@ -159,6 +162,11 @@ jobs:
       # Save test results for timing analysis
       - store_test_results:
           path: test_results
+      - when:
+          condition: << parameters.store_screenshots >>
+          steps:
+            - store_artifacts:
+              path: tmp/screenshots
 
       - when:
           condition: << parameters.report_coverage >>

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -163,10 +163,7 @@ jobs:
       - store_test_results:
           path: test_results
       - when:
-          condition:
-            and:
-              - << parameters.store_screenshots >>
-              - not: << parameters.report_coverage >>
+          condition: << parameters.store_screenshots >>
           steps:
             - store_artifacts:
               path: tmp/screenshots


### PR DESCRIPTION
Optionally store screenshots from failed rspec runs in CI.  For example, [like this](https://app.circleci.com/pipelines/github/tablexi/communicationbridge-pilot/102/workflows/6f2e21ac-db23-4eed-8cfc-9e3494baaf60/jobs/300/artifacts).