### PR TITLE
Use the latest aws-s3 orb

### DIFF
--- a/scripts/validate-orbs.sh
+++ b/scripts/validate-orbs.sh
@@ -3,4 +3,9 @@
 for ORB in src/*; do
   echo "Validating $ORB ..."
   circleci orb validate $ORB
+  exit_code=$?
+  if [ $exit_code != 0 ]; then
+    echo "There was an error validating $ORB" 1>&2
+    exit $exit_code
+  fi
 done

--- a/src/react.yml
+++ b/src/react.yml
@@ -4,7 +4,7 @@ version: 2.1
 default_node_version: &default_node_version 14.8.0
 
 orbs:
-  aws-s3: circleci/aws-s3@1.0.11
+  aws-s3: circleci/aws-s3@2.0.0
 
 executors:
   node:
@@ -25,11 +25,9 @@ commands:
       - aws-s3/sync:
           from: build/static/
           to: 's3://${S3_BUCKET}/static/'
-          overwrite: true
       - aws-s3/sync:
           from: build/
           to: 's3://${S3_BUCKET}/'
-          overwrite: true
 
   fetch_dependencies:
     steps:


### PR DESCRIPTION
This PR updates the aws-s3 orb to the latest so we can take advantage of AWS CLI version 2.

We're currently on AWS CLI version 1 and we've run out of grace for the required Python version. So [partner portal build](https://app.circleci.com/pipelines/github/tablexi/ama_edhub_partner_portal/775/workflows/1cd142e5-6bbb-4b05-bd33-3ce8109c877e/jobs/2696) is currently failing to deploy.

v2 however should not have the same problem according to [AWS announcement](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/).

[UPDATE]
I've also updated the test script to return the correct exit code after I noticed that the original PR CI build passed the tests even though validation failed. See https://app.circleci.com/pipelines/github/tablexi/circleci-orbs/80/workflows/89f8792a-020c-4a4a-9a39-67b8f14d671d/jobs/159

Please review