### PR TITLE
Ensure aws sync does not keep copies of files that no longer exist on…

### DIFF
--- a/src/react.yml
+++ b/src/react.yml
@@ -23,9 +23,11 @@ commands:
           at: ~/tmp
       - run: CI=false npm run build
       - aws-s3/sync:
+          arguments: '--delete'
           from: build/static/
           to: 's3://${S3_BUCKET}/static/'
       - aws-s3/sync:
+          arguments: '--delete'
           from: build/
           to: 's3://${S3_BUCKET}/'
 


### PR DESCRIPTION
This PR ensures aws sync does not keep copies of files that no longer exist on source. 

For more info on the flag, see AWS CLI [documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/sync.html).