### PR TITLE
Update apt-get to fix issue due to older base-linux image.

### DIFF
--- a/CHANGELOG-node.md
+++ b/CHANGELOG-node.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to the src/node.yml will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [0.0.5] - 2020-09-16
+
+- First release documented in CHANGELOG-node.md

--- a/CHANGELOG-react.md
+++ b/CHANGELOG-react.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to the src/react.yml will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [0.1.0] - 2021-07-22
+
+- Upgrade `aws-s3` version within `react` orb to 2.0.0

--- a/CHANGELOG-standard.md
+++ b/CHANGELOG-standard.md
@@ -1,13 +1,15 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to the src/standard.yml will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [0.0.10] - 2021-08-23
+
 - Add `check_annotate` job, to help ensure that annotations stay up to date on projects
-- Upgrade `aws-s3` version within `react` orb to 2.0.0
+- Update `load_db_schema` task to handle changes to the apt-get repository which removed some needed libraries.
 
 ## [0.0.9] - 2020-09-03
 

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ To publish production-versions of the orbs, you must be a TXI Admin.
 
 For more details: https://github.com/CircleCI-Public/config-preview-sdk/blob/master/docs/orbs-authoring.md
 
-Before publishing, please consider updating the CHANGELOG.md.
+Before publishing, please consider updating the CHANGELOG-standard.md or CHANGELOG-react.md or CHANGELOG-node.md as appropriate.
 
 Command to publish the current `dev` version:
 

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -43,11 +43,11 @@ commands:
       - when:
           condition: << parameters.mysql_db_type >>
           steps:
-            - run: if [ -e db/structure.sql ]; then sudo apt-get update && sudo apt-get install -y default-mysql-client; fi
+            - run: if [ -e db/structure.sql ]; then sudo apt-get --allow-releaseinfo-change update && sudo apt-get install -y default-mysql-client; fi
       - unless:
           condition: << parameters.mysql_db_type >>
           steps:
-            - run: if [ -e db/structure.sql ]; then sudo apt-get update && sudo apt-get install -y postgresql-client; fi
+            - run: if [ -e db/structure.sql ]; then sudo apt-get --allow-releaseinfo-change update && sudo apt-get install -y postgresql-client; fi
 
       - run: if [ -e db/schema.rb ]; then bundle exec rake db:schema:load; fi
       - run: if [ -e db/structure.sql ]; then bundle exec rake db:structure:load; fi


### PR DESCRIPTION
Splits CHANGELOG into 3, since this repository manages 3 separate orbs in the tablexi namespace