### PR TITLE
Add certificate step and upgrade browser-tools

### DIFF
--- a/CHANGELOG-standard.md
+++ b/CHANGELOG-standard.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.0.12] - 2023-03-16
+
+- Add `apt install -y ca-certificates` before installing `tzdata`
+- Upgrade to `circleci/browser-tools@1.4.1`
+
 ## [0.0.11] - 2022-02-03
 
 - Add install_bundler step to install correct version of bundler before running any bundler commands. Leverage this in all other jobs where we use bundler

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -41,7 +41,7 @@ commands:
         type: boolean
         default: false
     steps:
-      - run: sudo apt-get --allow-releaseinfo-change update && sudo apt-get install -y tzdata
+      - run: sudo apt install -y ca-certificates && sudo apt-get --allow-releaseinfo-change update && sudo apt-get install -y tzdata
       # Install the database library, so that we can run rake db:structure:load
       - when:
           condition: << parameters.mysql_db_type >>

--- a/src/standard.yml
+++ b/src/standard.yml
@@ -1,7 +1,7 @@
 description: "A set of standard steps which we use for projects at Table XI"
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.1
+  browser-tools: circleci/browser-tools@1.4.1
 commands:
   wait_for_other_builds:
     description: "Ensure no earlier numbered job (of this branch) is running"


### PR DESCRIPTION
- Add `apt install -y ca-certificates` before installing `tzdata`
- Upgrade to `circleci/browser-tools@1.4.1`

This is intended to fix a certificate error installing `tzdata`:
```
The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 
```